### PR TITLE
Use eslint recommended

### DIFF
--- a/app/frontend/components/app-header.tsx
+++ b/app/frontend/components/app-header.tsx
@@ -62,7 +62,7 @@ const rightNavItems: NavItem[] = [
 const activeItemStyles =
   "text-neutral-900 dark:bg-neutral-800 dark:text-neutral-100"
 
-type AppHeaderProps = {
+interface AppHeaderProps {
   breadcrumbs?: BreadcrumbItem[]
 }
 

--- a/app/frontend/components/app-shell.tsx
+++ b/app/frontend/components/app-shell.tsx
@@ -2,7 +2,7 @@ import { useState } from "react"
 
 import { SidebarProvider } from "@/components/ui/sidebar"
 
-type AppShellProps = {
+interface AppShellProps {
   children: React.ReactNode
   variant?: "header" | "sidebar"
 }

--- a/app/frontend/components/form.tsx
+++ b/app/frontend/components/form.tsx
@@ -9,7 +9,7 @@ import { cn } from "@/lib/utils"
 
 type FormDataType = Record<string, FormDataConvertible>
 
-type FormContextType<TForm extends FormDataType = FormDataType> = {
+interface FormContextType<TForm extends FormDataType = FormDataType> {
   form?: InertiaFormProps<TForm>
 }
 
@@ -45,10 +45,10 @@ function Form<TForm extends FormDataType = FormDataType>({
   )
 }
 
-type FormFieldContextType<
+interface FormFieldContextType<
   TForm extends FormDataType = FormDataType,
   TName extends keyof TForm = keyof TForm,
-> = {
+> {
   name: TName
 }
 
@@ -88,7 +88,7 @@ const FormField = <
   )
 }
 
-type FieldProps = {
+interface FieldProps {
   id: string
   name: string
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
@@ -150,7 +150,7 @@ const useFormField = () => {
   }
 }
 
-type FormItemContextValue = {
+interface FormItemContextValue {
   id: string
 }
 

--- a/app/frontend/components/placeholder-pattern.tsx
+++ b/app/frontend/components/placeholder-pattern.tsx
@@ -1,6 +1,6 @@
 import { useId } from "react"
 
-type PlaceholderPatternProps = {
+interface PlaceholderPatternProps {
   className?: string
 }
 

--- a/app/frontend/components/user-menu-content.tsx
+++ b/app/frontend/components/user-menu-content.tsx
@@ -12,7 +12,7 @@ import { useMobileNavigation } from "@/hooks/use-mobile-navigation"
 import { sessionPath, settingsProfilePath } from "@/routes"
 import { type User } from "@/types"
 
-type UserMenuContentProps = {
+interface UserMenuContentProps {
   auth: {
     session: {
       id: string

--- a/app/frontend/entrypoints/inertia.ts
+++ b/app/frontend/entrypoints/inertia.ts
@@ -5,7 +5,7 @@ import { createRoot } from "react-dom/client"
 import { initializeTheme } from "@/hooks/use-appearance"
 
 // Temporary type definition, until @inertiajs/react provides one
-type ResolvedComponent = {
+interface ResolvedComponent {
   default: ReactNode & { layout?: (page: ReactNode) => ReactNode }
   layout?: (page: ReactNode) => ReactNode
 }

--- a/app/frontend/layouts/app-layout.tsx
+++ b/app/frontend/layouts/app-layout.tsx
@@ -5,7 +5,7 @@ import { useFlash } from "@/hooks/use-flash"
 import AppLayoutTemplate from "@/layouts/app/app-sidebar-layout"
 import { type BreadcrumbItem } from "@/types"
 
-type AppLayoutProps = {
+interface AppLayoutProps {
   children: ReactNode
   breadcrumbs?: BreadcrumbItem[]
 }

--- a/app/frontend/layouts/auth/auth-simple-layout.tsx
+++ b/app/frontend/layouts/auth/auth-simple-layout.tsx
@@ -4,7 +4,7 @@ import { type PropsWithChildren } from "react"
 import AppLogoIcon from "@/components/app-logo-icon"
 import { rootPath } from "@/routes"
 
-type AuthLayoutProps = {
+interface AuthLayoutProps {
   name?: string
   title?: string
   description?: string

--- a/app/frontend/layouts/auth/auth-split-layout.tsx
+++ b/app/frontend/layouts/auth/auth-split-layout.tsx
@@ -4,7 +4,7 @@ import { type PropsWithChildren } from "react"
 import AppLogoIcon from "@/components/app-logo-icon"
 import { rootPath } from "@/routes"
 
-type AuthLayoutProps = {
+interface AuthLayoutProps {
   title?: string
   description?: string
 }

--- a/app/frontend/pages/home/index.tsx
+++ b/app/frontend/pages/home/index.tsx
@@ -4,7 +4,7 @@ import AppLogoIcon from "@/components/app-logo-icon.tsx"
 import { dashboardPath, signInPath } from "@/routes"
 import { Auth } from "@/types"
 
-type WelcomeParams = {
+interface WelcomeParams {
   auth: Auth
 }
 

--- a/app/frontend/pages/identity/password_resets/edit.tsx
+++ b/app/frontend/pages/identity/password_resets/edit.tsx
@@ -9,12 +9,12 @@ import { Label } from "@/components/ui/label"
 import AuthLayout from "@/layouts/auth-layout"
 import { identityPasswordResetPath } from "@/routes"
 
-type ResetPasswordProps = {
+interface ResetPasswordProps {
   sid: string
   email: string
 }
 
-type ResetPasswordForm = {
+interface ResetPasswordForm {
   sid: string
   email: string
   password: string
@@ -22,13 +22,14 @@ type ResetPasswordForm = {
 }
 
 export default function ResetPassword({ sid, email }: ResetPasswordProps) {
-  const { data, setData, put, processing, errors, reset } =
-    useForm<ResetPasswordForm>({
-      sid: sid,
-      email: email,
-      password: "",
-      password_confirmation: "",
-    })
+  const { data, setData, put, processing, errors, reset } = useForm<
+    Required<ResetPasswordForm>
+  >({
+    sid: sid,
+    email: email,
+    password: "",
+    password_confirmation: "",
+  })
 
   const submit: FormEventHandler = (e) => {
     e.preventDefault()

--- a/app/frontend/pages/sessions/new.tsx
+++ b/app/frontend/pages/sessions/new.tsx
@@ -10,20 +10,20 @@ import { Label } from "@/components/ui/label"
 import AuthLayout from "@/layouts/auth-layout"
 import { newIdentityPasswordResetPath, signInPath, signUpPath } from "@/routes"
 
-type LoginForm = {
+interface LoginForm {
   email: string
   password: string
   remember: boolean
 }
 
 export default function Login() {
-  const { data, setData, post, processing, errors, reset } = useForm<LoginForm>(
-    {
-      email: "",
-      password: "",
-      remember: false,
-    },
-  )
+  const { data, setData, post, processing, errors, reset } = useForm<
+    Required<LoginForm>
+  >({
+    email: "",
+    password: "",
+    remember: false,
+  })
 
   const submit: FormEventHandler = (e) => {
     e.preventDefault()

--- a/app/frontend/pages/settings/sessions/index.tsx
+++ b/app/frontend/pages/settings/sessions/index.tsx
@@ -9,7 +9,7 @@ import SettingsLayout from "@/layouts/settings/layout"
 import { sessionPath, settingsSessionsPath } from "@/routes"
 import { type BreadcrumbItem, type SharedData } from "@/types"
 
-type Session = {
+interface Session {
   id: string
   user_agent: string
   ip_address: string

--- a/app/frontend/pages/users/new.tsx
+++ b/app/frontend/pages/users/new.tsx
@@ -10,7 +10,7 @@ import { Label } from "@/components/ui/label"
 import AuthLayout from "@/layouts/auth-layout"
 import { signInPath, signUpPath } from "@/routes"
 
-type RegisterForm = {
+interface RegisterForm {
   name: string
   email: string
   password: string
@@ -18,13 +18,14 @@ type RegisterForm = {
 }
 
 export default function Register() {
-  const { data, setData, post, processing, errors, reset } =
-    useForm<RegisterForm>({
-      name: "",
-      email: "",
-      password: "",
-      password_confirmation: "",
-    })
+  const { data, setData, post, processing, errors, reset } = useForm<
+    Required<RegisterForm>
+  >({
+    name: "",
+    email: "",
+    password: "",
+    password_confirmation: "",
+  })
 
   const submit: FormEventHandler = (e) => {
     e.preventDefault()

--- a/app/frontend/ssr/ssr.ts
+++ b/app/frontend/ssr/ssr.ts
@@ -4,7 +4,7 @@ import { ReactNode, createElement } from "react"
 import ReactDOMServer from "react-dom/server"
 
 // Temporary type definition, until @inertiajs/react provides one
-type ResolvedComponent = {
+interface ResolvedComponent {
   default: ReactNode & { layout?: (page: ReactNode) => ReactNode }
   layout?: (page: ReactNode) => ReactNode
 }

--- a/app/frontend/types/index.ts
+++ b/app/frontend/types/index.ts
@@ -1,41 +1,41 @@
 import { LucideIcon } from "lucide-react"
 
-export type Auth = {
+export interface Auth {
   user: User
   session: {
     id: string
   }
 }
 
-export type BreadcrumbItem = {
+export interface BreadcrumbItem {
   title: string
   href: string
 }
 
-export type NavGroup = {
+export interface NavGroup {
   title: string
   items: NavItem[]
 }
 
-export type NavItem = {
+export interface NavItem {
   title: string
   url: string
   icon?: LucideIcon | null
   isActive?: boolean
 }
 
-export type Flash = {
+export interface Flash {
   alert?: string
   notice?: string
 }
 
-export type SharedData = {
+export interface SharedData {
   auth: Auth
   flash: Flash
   [key: string]: unknown
 }
 
-export type User = {
+export interface User {
   id: number
   name: string
   email: string

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -31,10 +31,5 @@ export default [
   {
     ...tseslint.configs.disableTypeChecked,
     files: ['**/*.js'],
-  },
-  {
-    rules: {
-      "@typescript-eslint/consistent-type-definitions": ["error", "type"],
-    }
   }
 ];


### PR DESCRIPTION
We can revert the ESLint rule `"@typescript-eslint/consistent-type-definitions"` back to its default setting since we've resolved the `useForm` and `interface` type issues by using the `Required` utility type now.

