### PR TITLE
Drop unused args & add form typing

### DIFF
--- a/app/frontend/components/delete-user.tsx
+++ b/app/frontend/components/delete-user.tsx
@@ -17,6 +17,10 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { usersPath } from "@/routes"
 
+interface DeleteUserForm {
+  password_challenge: string
+}
+
 export default function DeleteUser() {
   const passwordInput = useRef<HTMLInputElement>(null)
   const {
@@ -27,7 +31,7 @@ export default function DeleteUser() {
     reset,
     errors,
     clearErrors,
-  } = useForm({ password_challenge: "" })
+  } = useForm<Required<DeleteUserForm>>({ password_challenge: "" })
 
   const deleteUser: FormEventHandler = (e) => {
     e.preventDefault()

--- a/app/frontend/pages/home/index.tsx
+++ b/app/frontend/pages/home/index.tsx
@@ -1,14 +1,13 @@
-import { Head, Link } from "@inertiajs/react"
+import { Head, Link, usePage } from "@inertiajs/react"
 
 import AppLogoIcon from "@/components/app-logo-icon.tsx"
 import { dashboardPath, signInPath } from "@/routes"
-import type { Auth } from "@/types"
+import type { SharedData } from "@/types"
 
-interface WelcomeParams {
-  auth: Auth
-}
+export default function Welcome() {
+  const page = usePage<SharedData>()
+  const { auth } = page.props
 
-export default function Welcome({ auth }: WelcomeParams) {
   return (
     <>
       <Head title="Welcome">

--- a/app/frontend/pages/identity/password_resets/new.tsx
+++ b/app/frontend/pages/identity/password_resets/new.tsx
@@ -10,8 +10,14 @@ import { Label } from "@/components/ui/label"
 import AuthLayout from "@/layouts/auth-layout"
 import { identityPasswordResetPath, signInPath } from "@/routes"
 
-export default function ForgotPassword({ status }: { status?: string }) {
-  const { data, setData, post, processing, errors } = useForm({
+interface ForgotPasswordForm {
+  email: string
+}
+
+export default function ForgotPassword() {
+  const { data, setData, post, processing, errors } = useForm<
+    Required<ForgotPasswordForm>
+  >({
     email: "",
   })
 
@@ -27,12 +33,6 @@ export default function ForgotPassword({ status }: { status?: string }) {
       description="Enter your email to receive a password reset link"
     >
       <Head title="Forgot password" />
-
-      {status && (
-        <div className="mb-4 text-center text-sm font-medium text-green-600">
-          {status}
-        </div>
-      )}
 
       <div className="space-y-6">
         <form onSubmit={submit}>

--- a/app/frontend/pages/settings/emails/show.tsx
+++ b/app/frontend/pages/settings/emails/show.tsx
@@ -19,7 +19,12 @@ const breadcrumbs: BreadcrumbItem[] = [
   },
 ]
 
-export default function Email({ status }: { status?: string }) {
+interface EmailForm {
+  password_challenge: string
+  email: string
+}
+
+export default function Email() {
   const currentPasswordInput = useRef<HTMLInputElement>(null)
 
   const { auth } = usePage<SharedData>().props
@@ -31,7 +36,7 @@ export default function Email({ status }: { status?: string }) {
     reset,
     processing,
     recentlySuccessful,
-  } = useForm({
+  } = useForm<Required<EmailForm>>({
     password_challenge: "",
     email: auth.user.email,
   })
@@ -93,12 +98,6 @@ export default function Email({ status }: { status?: string }) {
                     Click here to resend the verification email.
                   </Link>
                 </p>
-
-                {status === "verification-link-sent" && (
-                  <div className="mt-2 text-sm font-medium text-green-600">
-                    A new verification link has been sent to your email address.
-                  </div>
-                )}
               </div>
             )}
 

--- a/app/frontend/pages/settings/passwords/show.tsx
+++ b/app/frontend/pages/settings/passwords/show.tsx
@@ -19,12 +19,18 @@ const breadcrumbs: BreadcrumbItem[] = [
   },
 ]
 
+interface PasswordForm {
+  password_challenge: string
+  password: string
+  password_confirmation: string
+}
+
 export default function Password() {
   const passwordInput = useRef<HTMLInputElement>(null)
   const currentPasswordInput = useRef<HTMLInputElement>(null)
 
   const { data, setData, errors, put, reset, processing, recentlySuccessful } =
-    useForm({
+    useForm<Required<PasswordForm>>({
       password_challenge: "",
       password: "",
       password_confirmation: "",

--- a/app/frontend/pages/settings/profiles/show.tsx
+++ b/app/frontend/pages/settings/profiles/show.tsx
@@ -20,11 +20,15 @@ const breadcrumbs: BreadcrumbItem[] = [
   },
 ]
 
+interface ProfileForm {
+  name: string
+}
+
 export default function Profile() {
   const { auth } = usePage<SharedData>().props
 
   const { data, setData, patch, errors, processing, recentlySuccessful } =
-    useForm({
+    useForm<Required<ProfileForm>>({
       name: auth.user.name,
     })
 

--- a/app/frontend/pages/settings/sessions/index.tsx
+++ b/app/frontend/pages/settings/sessions/index.tsx
@@ -1,5 +1,4 @@
-import { Transition } from "@headlessui/react"
-import { Head, Link, useForm, usePage } from "@inertiajs/react"
+import { Head, Link, usePage } from "@inertiajs/react"
 
 import HeadingSmall from "@/components/heading-small"
 import { Badge } from "@/components/ui/badge"
@@ -7,14 +6,7 @@ import { Button } from "@/components/ui/button"
 import AppLayout from "@/layouts/app-layout"
 import SettingsLayout from "@/layouts/settings/layout"
 import { sessionPath, settingsSessionsPath } from "@/routes"
-import type { BreadcrumbItem, SharedData } from "@/types"
-
-interface Session {
-  id: string
-  user_agent: string
-  ip_address: string
-  created_at: string
-}
+import type { BreadcrumbItem, Session, SharedData } from "@/types"
 
 const breadcrumbs: BreadcrumbItem[] = [
   {
@@ -23,8 +15,11 @@ const breadcrumbs: BreadcrumbItem[] = [
   },
 ]
 
-export default function Sessions({ sessions }: { sessions: Session[] }) {
-  const { recentlySuccessful } = useForm()
+interface SessionsProps {
+  sessions: Session[]
+}
+
+export default function Sessions({ sessions }: SessionsProps) {
   const { auth } = usePage<SharedData>().props
 
   return (
@@ -77,16 +72,6 @@ export default function Sessions({ sessions }: { sessions: Session[] }) {
               </div>
             ))}
           </div>
-
-          <Transition
-            show={recentlySuccessful}
-            enter="transition ease-in-out"
-            enterFrom="opacity-0"
-            leave="transition ease-in-out"
-            leaveTo="opacity-0"
-          >
-            <p className="text-sm text-neutral-600">Session terminated</p>
-          </Transition>
         </div>
       </SettingsLayout>
     </AppLayout>

--- a/app/frontend/routes/index.js
+++ b/app/frontend/routes/index.js
@@ -9,7 +9,7 @@ const __jsr = (
 () => {
     const hasProp = (value, key) => Object.prototype.hasOwnProperty.call(value, key);
     let NodeTypes;
-    ((NodeTypes) => {
+    (function (NodeTypes) {
         NodeTypes[NodeTypes["GROUP"] = 1] = "GROUP";
         NodeTypes[NodeTypes["CAT"] = 2] = "CAT";
         NodeTypes[NodeTypes["SYMBOL"] = 3] = "SYMBOL";
@@ -42,7 +42,9 @@ const __jsr = (
         AMD: {
             define(routes) {
                 if (define) {
-                    define([], () => routes);
+                    define([], function () {
+                        return routes;
+                    });
                 }
             },
             isSupported() {

--- a/app/frontend/types/index.ts
+++ b/app/frontend/types/index.ts
@@ -2,19 +2,12 @@ import type { LucideIcon } from "lucide-react"
 
 export interface Auth {
   user: User
-  session: {
-    id: string
-  }
+  session: Pick<Session, "id">
 }
 
 export interface BreadcrumbItem {
   title: string
   href: string
-}
-
-export interface NavGroup {
-  title: string
-  items: NavItem[]
 }
 
 export interface NavItem {
@@ -44,4 +37,11 @@ export interface User {
   created_at: string
   updated_at: string
   [key: string]: unknown // This allows for additional properties...
+}
+
+export interface Session {
+  id: string
+  user_agent: string
+  ip_address: string
+  created_at: string
 }


### PR DESCRIPTION
This PR:
- removes unused `status` args (Rails starter uses flashes instead) 
- adds types to all `useForm` hooks